### PR TITLE
Add leave mission feature

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { addMissions } from './redux/missions/missions';
+import { useDispatch, useSelector } from 'react-redux';
+import { addMissions, joinMission } from './redux/missions/missions';
+import '../styles/style.scss';
 
 const Missions = () => {
   const dispatch = useDispatch();
@@ -14,19 +15,48 @@ const Missions = () => {
         });
     }
   }, [dispatch, missions.length]);
+
+  const handleJoinMission = (missionId) => {
+    dispatch(joinMission(missionId));
+  };
+
   return (
-    <div>
-      <h2>Missions</h2>
-      <ul>
+    <div className="mission-container">
+      <h2 className="mission-title">Missions</h2>
+      <ul className="mission-list">
         {missions.map((mission) => (
-          <li key={mission.mission_id}>
-            <h3>{mission.mission_name}</h3>
-            <p>{mission.description}</p>
+          <li className="mission-item" key={mission.mission_id}>
+            <h3 className="mission-name">{mission.mission_name}</h3>
+            <p className="mission-description">{mission.description}</p>
+            <div className="mission-badge-container">
+              {mission.reserved ? (
+                <div className="active-member-badge">Active Member</div>
+              ) : (
+                <div className="not-a-member-badge">NOT A MEMBER</div>
+              )}
+            </div>
+            <div className="mission-action-container">
+              {mission.reserved ? (
+                <button
+                  type="button"
+                  className="leave-mission-button"
+                >
+                  Leave Mission
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="join-mission-button"
+                  onClick={() => handleJoinMission(mission.mission_id)}
+                >
+                  Join Mission
+                </button>
+              )}
+            </div>
           </li>
         ))}
       </ul>
     </div>
   );
 };
-
 export default Missions;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { addMissions, joinMission } from './redux/missions/missions';
+import { addMissions, joinMission, leaveMission } from './redux/missions/missions';
 import '../styles/style.scss';
 
 const Missions = () => {
@@ -18,6 +18,10 @@ const Missions = () => {
 
   const handleJoinMission = (missionId) => {
     dispatch(joinMission(missionId));
+  };
+
+  const handleLeaveMission = (missionId) => {
+    dispatch(leaveMission(missionId));
   };
 
   return (
@@ -40,6 +44,7 @@ const Missions = () => {
                 <button
                   type="button"
                   className="leave-mission-button"
+                  onClick={() => handleLeaveMission(mission.mission_id)}
                 >
                   Leave Mission
                 </button>

--- a/src/components/redux/missions/missions.js
+++ b/src/components/redux/missions/missions.js
@@ -7,9 +7,17 @@ export const missionsSlice = createSlice({
     addMissions: (state, action) => {
       state.push(...action.payload);
     },
+    joinMission: (state, action) => {
+      const newState = state.map((mission) => {
+        if (mission.mission_id !== action.payload) return mission;
+        return { ...mission, reserved: true };
+      });
+      return newState;
+    },
+
   },
 });
 
-export const { addMissions } = missionsSlice.actions;
+export const { addMissions, joinMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/components/redux/missions/missions.js
+++ b/src/components/redux/missions/missions.js
@@ -14,10 +14,16 @@ export const missionsSlice = createSlice({
       });
       return newState;
     },
-
+    leaveMission: (state, action) => {
+      const newState = state.map((mission) => {
+        if (mission.mission_id !== action.payload) return mission;
+        return { ...mission, reserved: false };
+      });
+      return newState;
+    },
   },
 });
 
-export const { addMissions, joinMission } = missionsSlice.actions;
+export const { addMissions, joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
Hello 👋, In this pull request the followings are done:

- When a user clicks the "Leave Mission" button, an action is dispatched to delete the user from the store.
- Missions that the user has joined already show a badge "Active Member" and a button "Leave Mission" instead of the "Join Mission" button (as per design).